### PR TITLE
fixed menu not showing after pvp game

### DIFF
--- a/chess/hud/menu.lua
+++ b/chess/hud/menu.lua
@@ -28,7 +28,6 @@ function initMenu()
             })
             :onRelease(function()
                 prepareGame()
-                panelGrid:setVisible(false)
                 menuActive = false
             end),
 


### PR DESCRIPTION
Removed panelGrid:setVisible(false), menu won't show anyway since it won't get drawn when inactive

Resolves #12 