### PR TITLE
fixed sleep for windows

### DIFF
--- a/chess/ai/random.lua
+++ b/chess/ai/random.lua
@@ -6,7 +6,11 @@ function table.empty (self)
 end
 
 function random_make_move()
-    os.execute("sleep " .. tonumber(1))      
+    if os.getenv("HOME") == nil then
+        os.execute("ping -n 2 localhost > NUL")
+    else
+        os.execute("sleep " .. tonumber(1))
+    end
     local aiMoves = {}
     local aiPiecePosFrom = {}
     local aiPiecePosTo = {}


### PR DESCRIPTION
Fixed the sleep function not working on windows (there is no sleep, I use ping instead as proposed here: http://lua-users.org/wiki/SleepFunction)

os.getenv("HOME") on linux returns something like: `/home/coldiv`
for windows it's `nil`